### PR TITLE
#70: Configurable exposed ports

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,4 +1,5 @@
 # Changes
 
+* [3.0.0](changes-2.1.0.md)
 * [2.1.0](changes-2.1.0.md)
 * [2.0.3](changes-2.0.3.md)

--- a/doc/changes/changes-3.0.0.md
+++ b/doc/changes/changes-3.0.0.md
@@ -1,0 +1,19 @@
+# Exasol Test Containers 3.0.0, released 2020-07-29
+
+Starting with this release the port numbers used for the test containers are read from the Exasol cluster configuration at runtime.
+
+This allows you to use Docker images that have the database service(s) or BucketFS service(s) running on non-standard ports.
+
+Keep in mind that you still need to expose the right port numbers at construction time using `withExposedPorts(...)`. The reason for this is that the cluster configuration is readable only after the container started and the container won't start if the database port is not exposed, since that prevents an alive-check.
+
+We had to make one not-backward compatible interface change. `getDatabaseNames()` on the `ClusterConfiguration` now returns a list instead of a set. This was necessary, because we need to know which the first listed database is, since this is always the one used for the initial start-up check.
+
+## Features / Enhancements
+ 
+* #70: Improved exposed port handling
+
+## Dependency updates
+
+* Updated `org.itsallcode:openfasttrace-maven-plugin` from 0.1.0 to 1.0.0
+* Updated `com.exasol:exasol-jdbc` from 6.2.3 to 6.2.5
+* Updated `org.mockito:mockito-junit-jupiter` from 3.3.3 to 3.4.4

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -158,6 +158,16 @@ If necessary you can even pick a specific Docker image revision (though in most 
 
 If you omit the Docker image revision, it always defaults to `d1`.
 
+### Using Non-standard Port Numbers
+
+Exasol's `docker-db` has a fixed cluster configuration. The ports for the database service and the BucketFS service are constant. That being said, if you want to experiment with your own Docker images, you might use different port numbers.
+
+As you will learn in section ["Automatic Cluster Configuration Parsing"](#automatic-cluster-configuration-parsing), the testcontainer can configure a lot of settings automatically by reading the cluster configuration.
+
+Unfortunately this in case of exposed ports, this mechanism kicks in too late. Ports must be exposed _before_ the container starts. And at that time the cluster configuration obviously is not available yet.
+
+That means if you use non-standard ports for your services, you must expose the ports manually using the "withExposedPorts(...)" method when you instantiate the container.
+
 ## Automatic Cluster Configuration Parsing
 
 Many integration tests rely on knowing the setup of the cluster. The Exasol test container comes with a parser that reads the cluster configuration from the running docker container.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>exasol-testcontainers</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
     <name>Test containers for Exasol on Docker</name>
     <description>This module provides abstraction for generation, startup, shutdown and use of an
         Exasol database running on Docker.
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>exasol-jdbc</artifactId>
-            <version>6.2.3</version>
+            <version>6.2.5</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.3.3</version>
+            <version>3.4.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -206,7 +206,7 @@
             <plugin>
                 <groupId>org.itsallcode</groupId>
                 <artifactId>openfasttrace-maven-plugin</artifactId>
-                <version>0.1.0</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <id>trace-requirements</id>

--- a/src/main/java/com/exasol/config/ClusterConfiguration.java
+++ b/src/main/java/com/exasol/config/ClusterConfiguration.java
@@ -17,6 +17,7 @@ public class ClusterConfiguration {
     private static final String SECTION_SEPARATOR = "/";
     private static final String GLOBAL_SECTION = "Global";
     private static final String DEFAULT_BUCKET_SECTION = "BucketFS:bfsdefault/Bucket:default";
+    private static final String DEFAULT_DATABASE_NAME = "DB1";
     private final Map<String, String> parameters;
 
     /**
@@ -115,12 +116,13 @@ public class ClusterConfiguration {
      *
      * @return list of database names
      */
-    public Set<String> getDatabaseNames() {
+    public List<String> getDatabaseNames() {
         return this.parameters.keySet() //
                 .stream() //
                 .filter(key -> key.startsWith(DATABASE_KEY_PREFIX)) //
                 .map(key -> key.substring(key.lastIndexOf(KEY_SEPARATOR) + 1).replaceAll("/.*", "")) //
-                .collect(Collectors.toSet());
+                .distinct() //
+                .collect(Collectors.toList());
     }
 
     /**
@@ -130,5 +132,54 @@ public class ClusterConfiguration {
      */
     public TimeZone getTimeZone() {
         return TimeZone.getTimeZone(this.parameters.get(GLOBAL_SECTION + SECTION_SEPARATOR + "Timezone"));
+    }
+
+    /**
+     * Get the default database configuration.
+     *
+     * @return database configuration
+     */
+    public DatabaseServiceConfiguration getDefaultDatabaseServiceConfiguration() {
+        return getDatabaseServiceConfiguration(DEFAULT_DATABASE_NAME);
+    }
+
+    /**
+     * Get the database configuration with the given name.
+     *
+     * @param databaseName name of the database in the configuration
+     *
+     * @return database configuration
+     */
+    public DatabaseServiceConfiguration getDatabaseServiceConfiguration(final String databaseName) {
+        return DatabaseServiceConfiguration.builder() //
+                .databaseName(databaseName) //
+                .port(Integer
+                        .parseInt(this.parameters.get(DATABASE_KEY_PREFIX + databaseName + SECTION_SEPARATOR + "Port"))) //
+                .build();
+    }
+
+    /**
+     * Get the database configuration with the given position in the configuration.
+     *
+     * @param position position of the database in the configuration
+     *
+     * @return database configuration
+     */
+    public DatabaseServiceConfiguration getDatabaseServiceConfiguration(final int position) {
+        return getDatabaseServiceConfiguration(getDatabaseNames().get(position));
+    }
+
+    /**
+     * Get the list of bucket FS service names.
+     *
+     * @return list of bucket FS service names
+     */
+    public List<String> getBucketFsServiceNames() {
+        return this.parameters.keySet() //
+                .stream() //
+                .filter(key -> key.startsWith(BUCKET_SERVICE_KEY_PREFIX)) //
+                .map(key -> key.substring(key.indexOf(KEY_SEPARATOR) + 1).replaceAll("/.*", "")) //
+                .distinct() //
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/exasol/config/DatabaseServiceConfiguration.java
+++ b/src/main/java/com/exasol/config/DatabaseServiceConfiguration.java
@@ -5,6 +5,7 @@ package com.exasol.config;
  */
 public class DatabaseServiceConfiguration {
     private final String databaseName;
+    private final int port;
 
     /**
      * Create a new instance of a {@link DatabaseServiceConfiguration}.
@@ -13,6 +14,7 @@ public class DatabaseServiceConfiguration {
      */
     public DatabaseServiceConfiguration(final Builder builder) {
         this.databaseName = builder.databaseName;
+        this.port = builder.port;
     }
 
     /**
@@ -22,6 +24,15 @@ public class DatabaseServiceConfiguration {
      */
     public String getDatabaseName() {
         return this.databaseName;
+    }
+
+    /**
+     * Get the TCP port the database listens on.
+     *
+     * @return database port
+     */
+    public int getPort() {
+        return this.port;
     }
 
     /**
@@ -38,6 +49,7 @@ public class DatabaseServiceConfiguration {
      */
     public static class Builder {
         private String databaseName;
+        private int port;
 
         /**
          * Set the name of the database provided by the service.
@@ -47,6 +59,17 @@ public class DatabaseServiceConfiguration {
          */
         public Builder databaseName(final String databaseName) {
             this.databaseName = databaseName;
+            return this;
+        }
+
+        /**
+         * Set the TCP port the database listens on.
+         *
+         * @param port database port
+         * @return builder instance for fluent programming
+         */
+        public Builder port(final int port) {
+            this.port = port;
             return this;
         }
 

--- a/src/main/java/com/exasol/containers/ExasolContainerConstants.java
+++ b/src/main/java/com/exasol/containers/ExasolContainerConstants.java
@@ -23,8 +23,8 @@ public final class ExasolContainerConstants {
     public static final String NAME = "exasol";
     public static final String JDBC_DRIVER_CLASS = "com.exasol.jdbc.EXADriver";
     public static final String BUCKETFS_DAEMON_LOG_FILENAME_PATTERN = "bucketfsd.*.log";
-    static final int CONTAINER_INTERNAL_DATABASE_PORT = 8888;
-    static final int CONTAINER_INTERNAL_BUCKETFS_PORT = 6583;
+    static final int DEFAULT_CONTAINER_INTERNAL_DATABASE_PORT = 8888;
+    static final int DEFAULT_CONTAINER_INTERNAL_BUCKETFS_PORT = 6583;
     public static final Set<String> SUPPORTED_ARCHIVE_EXTENSIONS = Set.of(".tar", ".tgz", ".tar.gz", ".zip");
 
     private ExasolContainerConstants() {

--- a/src/test/java/com/exasol/containers/ExasolContainerIT.java
+++ b/src/test/java/com/exasol/containers/ExasolContainerIT.java
@@ -69,7 +69,7 @@ class ExasolContainerIT {
     @Test
     void testGetLivenessCheckPortNumbers() {
         final Set<Integer> expectedPorts = Set
-                .of(CONTAINER.getMappedPort(ExasolContainerConstants.CONTAINER_INTERNAL_DATABASE_PORT));
+                .of(CONTAINER.getMappedPort(ExasolContainerConstants.DEFAULT_CONTAINER_INTERNAL_DATABASE_PORT));
         assertThat(CONTAINER.getLivenessCheckPortNumbers(), equalTo(expectedPorts));
     }
 

--- a/src/test/java/com/exasol/exaconf/ConfigurationParserTest.java
+++ b/src/test/java/com/exasol/exaconf/ConfigurationParserTest.java
@@ -86,4 +86,27 @@ class ConfigurationParserTest {
         final ClusterConfiguration clusterConfiguration = parseConfiguration("[Global]\nTimezone = Asia/Taipei");
         assertThat(clusterConfiguration.getTimeZone().toString(), containsString("Asia/Taipei"));
     }
+
+    @Test
+    void testGetDatabaseServiceConfiguration() {
+        final ClusterConfiguration clusterConfiguration = parseConfiguration("[DB : DB1]\nPort = 3456");
+        final DatabaseServiceConfiguration databaseServiceConfiguration = clusterConfiguration
+                .getDefaultDatabaseServiceConfiguration();
+        assertAll(() -> assertThat(databaseServiceConfiguration.getDatabaseName(), equalTo("DB1")),
+                () -> assertThat(databaseServiceConfiguration.getPort(), equalTo(3456)));
+    }
+
+    @Test
+    void testGetDatabaseNames() {
+        final ClusterConfiguration clusterConfiguration = parseConfiguration(
+                "[DB : Fred]\nPort=1\nNodes=11\n[DB : Wilma]\nPort=2\n[DB : Barney]\nPort=3");
+        assertThat(clusterConfiguration.getDatabaseNames(), contains("Fred", "Wilma", "Barney"));
+    }
+
+    @Test
+    void testGetBucketFsServiceNames() {
+        final ClusterConfiguration clusterConfiguration = parseConfiguration(
+                "[BucketFS : Fred]\nHttpPort=1\n[[Bucket : default]]\n[BucketFS : Wilma]\nHttpPort=2\n[BucketFS : Barney]\nHttpPort=3");
+        assertThat(clusterConfiguration.getBucketFsServiceNames(), contains("Fred", "Wilma", "Barney"));
+    }
 }


### PR DESCRIPTION
Closes #70.

Note that this solution consists of two parts, to solve a chicken-of-the-egg problem:
* Users need to expose non-standard-ports by hand _at the time when the `ExasolContainer` is instatiated_
* Database and BucketFS ports are now read from the config