### PR TITLE
Bug/#254 fix support information retriever v8

### DIFF
--- a/doc/changes/changes_7.1.2.md
+++ b/doc/changes/changes_7.1.2.md
@@ -1,4 +1,4 @@
-# Test Containers for Exasol on Docker 7.1.2, released 2024-??-??
+# Test Containers for Exasol on Docker 7.1.2, released 2024-10-22
 
 Code name: Allow withExposedPorts
 
@@ -8,11 +8,14 @@ This release fixes an issue that prevented the container startup when using the 
 The installation of ScriptLanguageContainers requires the BucketFS internal port to be available, but this shouldn't 
 be the case when no SLC has been requested to be installed.
 
-It also bumps default docker image to 7.1.30.
+It also adapts the support of information retrieval at exit to work with Exasol v8.
+
+The default docker image was bumped to 7.1.30.
 
 ## Bugfix
 
 * #257: Container startup fails when using withExposedPorts()
+* #254: Adapt SupportInformationRetriever for Exasol v8
 
 ## Dependency Updates
 

--- a/src/main/java/com/exasol/support/SupportInformationRetriever.java
+++ b/src/main/java/com/exasol/support/SupportInformationRetriever.java
@@ -26,7 +26,7 @@ public class SupportInformationRetriever {
     /** Name of the property that allows overriding the monitored container exit */
     public static final String MONITORED_EXIT_PROPERTY = "com.exasol.containers.monitored_exit";
     static final String SUPPORT_ARCHIVE_PREFIX = "exacluster_debuginfo_";
-    private static final String EXASUPPORT_EXECUTABLE = "exasupport";
+    private static final String[] EXASUPPORT_COMMAND = {"exasupport", "-d", "0"};
     private static final Logger LOGGER = LoggerFactory.getLogger(SupportInformationRetriever.class);
     private static final String MAPPED_HOST_DIRECTORY = "/exa/tmp/support";
     private static final ExitType DEFAULT_MONITORED_EXIT_TYPE = ExitType.EXIT_NONE;
@@ -95,7 +95,7 @@ public class SupportInformationRetriever {
     @SuppressWarnings("java:S112")
     private void createArchiveBundle(final ExitType exitType) {
         try {
-            final ExecResult result = this.container.execInContainer(EXASUPPORT_EXECUTABLE);
+            final ExecResult result = this.container.execInContainer(EXASUPPORT_COMMAND);
             if (result.getExitCode() == ExitCode.OK) {
                 final String filename = extractFilenameFromConsoleMessage(result);
                 final String hostPath = getHostPath(filename);

--- a/src/test/java/com/exasol/support/SupportInformationRetrieverIT.java
+++ b/src/test/java/com/exasol/support/SupportInformationRetrieverIT.java
@@ -32,13 +32,6 @@ class SupportInformationRetrieverIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(SupportInformationRetrieverIT.class);
     private static final String SYSINFO_FILENAME = "sysinfo.txt";
 
-    @BeforeAll
-    static void assumeSupportPackageSupported() {
-        // These tests don't work with Exasol v8. We will fix this in
-        // https://github.com/exasol/exasol-testcontainers/issues/254
-        ExasolContainerAssumptions.assumeDockerDbVersionNotOverriddenToBelowExasolEight();
-    }
-
     // [itest->dsn~configure-support-information-retriever-via-api~1]
     @Test
     void testWriteSupportBundleOnExit(@TempDir final Path tempDir) {


### PR DESCRIPTION
Closes #254 

Since v8 the `exasupport` command requires the `-d` parameter to be explicitly set.
Previous versions defaulted to `-d 0` if the parameter was not set.

Using `exasupport -d 0` works with Exasol v8 as well as older versions retaining the same behaviour.